### PR TITLE
ci: add gha build workflow to docker hub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: CI to Docker Hub
+
+on:
+  push:
+    branches:
+    - '**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@c559dac9da053e1196470d6fe7b04d8ec1b0b617 # v3.x
+      
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ env.GITHUB_REPOSITORY_NAME_PART}}:${{ env.GITHUB_EVENT_REF_SLUG_URL}}


### PR DESCRIPTION
For this workflow to work you have to add 2 secrets into the repository, as described here: https://docs.docker.com/ci-cd/github-actions/#set-up-a-docker-project

DOCKER_HUB_USERNAME
DOCKER_HUB_ACCESS_TOKEN

Also note this will push the image under the name `debian-debug-image` as it's the name of this GitHub repository